### PR TITLE
Match output printing to OpenSSL style

### DIFF
--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -217,12 +217,14 @@ int main(){
 
 
     //Prepare test data
-    unsigned char buf[64] = {0};
-    uint64_t      *prt;
-    prt = (uint64_t*) buf;
+    unsigned char buf[0];
 
     //Initialize digest and process buffer
+    char buflen = 0;
+    unsigned char rbuf[64];
+    CSHA512().Write(buf, buflen).Finalize(rbuf);
     CSHA512 hasher;
+    hasher.Write(buf, 0);   //Tried both 3 and 64
 
     //Finalize digest
     hasher.Finalize(buf);
@@ -230,16 +232,10 @@ int main(){
     //Print final digest 
     std::cout << "Dogecoin's Bitcoin Sha512 Implementation (Input = 0xffffff )" << std::endl; 
     std::cout << "Digest is: "; 
-    for( int kk=0; kk < 8; kk++){
-        std::cout << std::hex
-                  << std::noshowbase
-                  << std::setw(16)
-                  << std::setfill('0') 
-                  << prt[ kk ];
-    }
-
-    std::cout << std::endl;
-
+    int i = 0;
+    for(i = 0; i < sizeof(rbuf); i++)
+       printf("%02x", buf[i]);
+    printf("\n");
 
     return 0;
 }


### PR DESCRIPTION
I don't think this is a complete answer, but it does produce matching hashes for me at least. Also verified from the command line:

````
$ echo "" | xxd -r -ps | openssl sha512
(stdin)= cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
````